### PR TITLE
Use drupal-finder to support non-web install directories.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "php": ">=8.3",
         "drupal/core": ">=10",
-        "vincentlanglet/twig-cs-fixer": "^3.0.2"
+        "vincentlanglet/twig-cs-fixer": "^3.0.2",
+        "webflo/drupal-finder": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/DrupalConfig.php
+++ b/src/DrupalConfig.php
@@ -7,6 +7,7 @@ namespace TwigCsFixerDrupal;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Template\TwigTransTokenParser;
 use Drupal\Core\Theme\ThemeManagerInterface;
+use DrupalFinder\DrupalFinderComposerRuntime;
 use TwigCsFixer\Config\Config;
 use TwigCsFixer\Rules\Whitespace\IndentRule;
 use TwigCsFixer\Standard\TwigCsFixer;
@@ -39,9 +40,9 @@ class DrupalConfig {
 
     // Add drupal/storybook support.
     if (class_exists('\TwigStorybook\Twig\TwigExtension') && class_exists('\TwigStorybook\Service\StoryCollector')) {
-      $drupalRoot = 'web';
+      $finder = new DrupalFinderComposerRuntime();
       $storyCollector = new \TwigStorybook\Service\StoryCollector();
-      $config->addTwigExtension(new \TwigStorybook\Twig\TwigExtension($storyCollector, $drupalRoot));
+      $config->addTwigExtension(new \TwigStorybook\Twig\TwigExtension($storyCollector, $finder->getDrupalRoot()));
     }
 
     // Load default ruleset.


### PR DESCRIPTION
Pull request in the original repository, by @davereid: https://github.com/wotnak/twig-cs-fixer-drupal/pull/4

Currently the configuration file hardcodes the web directory assumed to be the docroot, but this might not be true for some projects. This pull request addresses this situation.