### PR TITLE
fix: avoid duplicate trans tag when symfony/twig-bridge is installed

### DIFF
--- a/src/DrupalConfig.php
+++ b/src/DrupalConfig.php
@@ -7,7 +7,6 @@ namespace TwigCsFixerDrupal;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Template\TwigTransTokenParser;
 use Drupal\Core\Theme\ThemeManagerInterface;
-use Symfony\Bridge\Twig\TokenParser\TransTokenParser;
 use DrupalFinder\DrupalFinderComposerRuntime;
 use TwigCsFixer\Config\Config;
 use TwigCsFixer\Rules\Variable\VariableNameRule;
@@ -30,7 +29,7 @@ class DrupalConfig {
     // Add drupal/core translation token parsers.
     // Skip if symfony/twig-bridge is installed, as StubbedEnvironment will
     // auto-register its own TransTokenParser for the same "trans" tag.
-    if (!class_exists(TransTokenParser::class)) {
+    if (!class_exists('\Symfony\Bridge\Twig\TokenParser\TransTokenParser')) {
       $config->addTokenParser(new TwigTransTokenParser());
     }
 

--- a/src/DrupalConfig.php
+++ b/src/DrupalConfig.php
@@ -7,6 +7,7 @@ namespace TwigCsFixerDrupal;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Template\TwigTransTokenParser;
 use Drupal\Core\Theme\ThemeManagerInterface;
+use Symfony\Bridge\Twig\TokenParser\TransTokenParser;
 use DrupalFinder\DrupalFinderComposerRuntime;
 use TwigCsFixer\Config\Config;
 use TwigCsFixer\Rules\Variable\VariableNameRule;
@@ -27,7 +28,11 @@ class DrupalConfig {
     $config->allowNonFixableRules();
 
     // Add drupal/core translation token parsers.
-    $config->addTokenParser(new TwigTransTokenParser());
+    // Skip if symfony/twig-bridge is installed, as StubbedEnvironment will
+    // auto-register its own TransTokenParser for the same "trans" tag.
+    if (!class_exists(TransTokenParser::class)) {
+      $config->addTokenParser(new TwigTransTokenParser());
+    }
 
     // Add drupal/twig_tweak support.
     if (class_exists('\Drupal\twig_tweak\TwigTweakExtension')) {


### PR DESCRIPTION
## Summary

- Fixes #17 — `Tag "trans" is already registered` error when `symfony/twig-bridge` is installed
- Guards the `TwigTransTokenParser` registration with a `class_exists` check for Symfony's `TransTokenParser`
- When `symfony/twig-bridge` is present, `StubbedEnvironment::handleOptionalDependencies()` already registers the `trans` tag, so adding Drupal's parser causes a `LogicException`

## How it works

`StubbedEnvironment` processes optional dependencies **before** custom token parsers from the config. When `symfony/twig-bridge` is installed (e.g. via `simplesamlphp`), it registers `Symfony\Bridge\Twig\TokenParser\TransTokenParser` for the `trans` tag. Twig's `StagingExtension::addTokenParser()` throws if a tag is already registered — there is no override mechanism.

This PR skips adding Drupal's `TwigTransTokenParser` when the Symfony class exists, since the tag will already be handled.